### PR TITLE
fix(kpm): align ioctl ABI with SukiSU-Ultra and harden handlers

### DIFF
--- a/kernel/kpm/compact.c
+++ b/kernel/kpm/compact.c
@@ -24,6 +24,7 @@
 #include <linux/version.h>
 #include <linux/export.h>
 #include <linux/slab.h>
+#include "infra/symbol_resolver.h"
 #include "kpm.h"
 #include "compact.h"
 #include "policy/allowlist.h"
@@ -49,6 +50,29 @@ static int sukisu_is_current_uid_manager(void)
     return is_manager();
 }
 
+/* KPM compact ABI (SukiSU): expose last known manager appid. */
+static uid_t sukisu_get_manager_uid(void)
+{
+#ifdef CONFIG_KSU_DISABLE_MANAGER
+    return 0;
+#else
+    if (ksu_last_manager_appid == (u16)KSU_INVALID_APPID)
+        return (uid_t)-1;
+    return (uid_t)ksu_last_manager_appid;
+#endif
+}
+
+static void sukisu_set_manager_uid(uid_t uid, int force)
+{
+#ifdef CONFIG_KSU_DISABLE_MANAGER
+    (void)uid;
+    (void)force;
+#else
+    if (force || ksu_last_manager_appid == (u16)KSU_INVALID_APPID)
+        ksu_last_manager_appid = (u16)(uid % PER_USER_RANGE);
+#endif
+}
+
 struct CompactAddressSymbol {
     const char *symbol_name;
     void *addr;
@@ -64,6 +88,8 @@ static struct CompactAddressSymbol address_symbol[] = {
     { "get_ap_mod_exclude", &sukisu_get_ap_mod_exclude },
     { "is_uid_should_umount", &sukisu_is_uid_should_umount },
     { "is_current_uid_manager", &sukisu_is_current_uid_manager },
+    { "get_manager_uid", &sukisu_get_manager_uid },
+    { "sukisu_set_manager_uid", &sukisu_set_manager_uid },
 };
 
 unsigned long sukisu_compact_find_symbol(const char *name)
@@ -71,14 +97,15 @@ unsigned long sukisu_compact_find_symbol(const char *name)
     int i;
     unsigned long addr;
 
-    for (i = 0; i < (sizeof(address_symbol) / sizeof(struct CompactAddressSymbol)); i++) {
+    for (i = 0; i < (int)(sizeof(address_symbol) / sizeof(struct CompactAddressSymbol)); i++) {
         struct CompactAddressSymbol *symbol = &address_symbol[i];
 
         if (strcmp(name, symbol->symbol_name) == 0)
             return (unsigned long)symbol->addr;
     }
 
-    addr = kallsyms_lookup_name(name);
+    /* Prefer exact resolver (binary search / CFI-aware) like SukiSU-Ultra. */
+    addr = find_kernel_symbol_exact(name);
     if (addr)
         return addr;
 

--- a/kernel/kpm/kpm.c
+++ b/kernel/kpm/kpm.c
@@ -7,6 +7,10 @@
  * 
  * 集成了 ELF 解析、内存布局、符号处理、重定位（支持 ARM64 重定位类型）
  * 并参照KernelPatch的标准KPM格式实现加载和控制
+ *
+ * ABI aligned with SukiSU-Ultra (struct ksu_kpm_cmd: control_code is a u64
+ * command value; result_code is a user pointer to int). Stub exports are
+ * intentionally non-optimized so KernelPatch can replace them at runtime.
  */
 
 #include <linux/kernel.h>
@@ -42,6 +46,10 @@
 
 #define KPM_NAME_LEN 32
 #define KPM_ARGS_LEN 1024
+#define KPM_PATH_LEN 256
+#define KPM_LIST_BUF_LEN 1024
+#define KPM_INFO_BUF_LEN 256
+#define KPM_VERSION_BUF_LEN 256
 
 #ifndef NO_OPTIMIZE
 #if defined(__GNUC__) && !defined(__clang__)
@@ -53,12 +61,16 @@
 #endif
 #endif
 
+/* Stubs: KernelPatch replaces these at runtime. Until then return -ENOSYS. */
+
 noinline NO_OPTIMIZE void sukisu_kpm_load_module_path(const char *path, const char *args, void *ptr, int *result)
 {
     pr_info("kpm: Stub function called (sukisu_kpm_load_module_path). "
             "path=%s args=%s ptr=%p\n",
             path, args, ptr);
 
+    if (result)
+        *result = -ENOSYS;
     __asm__ volatile("nop");
 }
 EXPORT_SYMBOL(sukisu_kpm_load_module_path);
@@ -69,6 +81,8 @@ noinline NO_OPTIMIZE void sukisu_kpm_unload_module(const char *name, void *ptr, 
             "name=%s ptr=%p\n",
             name, ptr);
 
+    if (result)
+        *result = -ENOSYS;
     __asm__ volatile("nop");
 }
 EXPORT_SYMBOL(sukisu_kpm_unload_module);
@@ -77,6 +91,8 @@ noinline NO_OPTIMIZE void sukisu_kpm_num(int *result)
 {
     pr_info("kpm: Stub function called (sukisu_kpm_num).\n");
 
+    if (result)
+        *result = -ENOSYS;
     __asm__ volatile("nop");
 }
 EXPORT_SYMBOL(sukisu_kpm_num);
@@ -87,6 +103,10 @@ noinline NO_OPTIMIZE void sukisu_kpm_info(const char *name, char *buf, int buffe
             "name=%s buffer=%p\n",
             name, buf);
 
+    if (size)
+        *size = 0;
+    if (buf && bufferSize > 0)
+        buf[0] = '\0';
     __asm__ volatile("nop");
 }
 EXPORT_SYMBOL(sukisu_kpm_info);
@@ -96,6 +116,12 @@ noinline NO_OPTIMIZE void sukisu_kpm_list(void *out, int bufferSize, int *result
     pr_info("kpm: Stub function called (sukisu_kpm_list). "
             "buffer=%p size=%d\n",
             out, bufferSize);
+
+    if (out && bufferSize > 0)
+        ((char *)out)[0] = '\0';
+    if (result)
+        *result = 0; /* 0 bytes written when no modules */
+    __asm__ volatile("nop");
 }
 EXPORT_SYMBOL(sukisu_kpm_list);
 
@@ -105,6 +131,8 @@ noinline NO_OPTIMIZE void sukisu_kpm_control(const char *name, const char *args,
             "name=%p args=%p arg_len=%ld\n",
             name, args, arg_len);
 
+    if (result)
+        *result = -ENOSYS;
     __asm__ volatile("nop");
 }
 EXPORT_SYMBOL(sukisu_kpm_control);
@@ -114,143 +142,246 @@ noinline NO_OPTIMIZE void sukisu_kpm_version(char *buf, int bufferSize)
     pr_info("kpm: Stub function called (sukisu_kpm_version). "
             "buffer=%p\n",
             buf);
+
+    if (buf && bufferSize > 0)
+        buf[0] = '\0';
+    __asm__ volatile("nop");
 }
 EXPORT_SYMBOL(sukisu_kpm_version);
+
+static int kpm_copy_result(unsigned long result_code, int res)
+{
+    if (!result_code)
+        return -EFAULT;
+    if (copy_to_user((void __user *)(uintptr_t)result_code, &res, sizeof(res)))
+        return -EFAULT;
+    return 0;
+}
 
 noinline int sukisu_handle_kpm(unsigned long control_code, unsigned long arg1, unsigned long arg2,
                                unsigned long result_code)
 {
-    int res = -1;
+    int res = -EINVAL;
+
     if (control_code == KSU_KPM_LOAD) {
-        char kernel_load_path[256] = { 0 };
-        char kernel_args_buffer[256] = { 0 };
+        char kernel_load_path[KPM_PATH_LEN] = { 0 };
+        char kernel_args_buffer[KPM_PATH_LEN] = { 0 };
+        long n;
 
         if (arg1 == 0) {
             res = -EINVAL;
             goto exit;
         }
 
-        if (!ksu_access_ok(arg1, sizeof(kernel_load_path))) {
+        if (!ksu_access_ok((void __user *)(uintptr_t)arg1, 1))
             goto invalid_arg;
-        }
 
-        strncpy_from_user((char *)&kernel_load_path, (const char *)arg1, sizeof(kernel_load_path));
+        n = strncpy_from_user(kernel_load_path, (const char __user *)(uintptr_t)arg1, sizeof(kernel_load_path));
+        if (n < 0) {
+            res = (int)n;
+            goto exit;
+        }
+        if (n == 0 || n >= (long)sizeof(kernel_load_path)) {
+            res = -ENAMETOOLONG;
+            goto exit;
+        }
 
         if (arg2 != 0) {
-            if (!ksu_access_ok(arg2, sizeof(kernel_args_buffer))) {
+            if (!ksu_access_ok((void __user *)(uintptr_t)arg2, 1))
                 goto invalid_arg;
-            }
 
-            strncpy_from_user((char *)&kernel_args_buffer, (const char *)arg2, sizeof(kernel_args_buffer));
+            n = strncpy_from_user(kernel_args_buffer, (const char __user *)(uintptr_t)arg2,
+                                  sizeof(kernel_args_buffer));
+            if (n < 0) {
+                res = (int)n;
+                goto exit;
+            }
+            if (n >= (long)sizeof(kernel_args_buffer)) {
+                res = -ENAMETOOLONG;
+                goto exit;
+            }
         }
 
-        sukisu_kpm_load_module_path((const char *)&kernel_load_path, (const char *)&kernel_args_buffer, NULL, &res);
+        sukisu_kpm_load_module_path(kernel_load_path, kernel_args_buffer, NULL, &res);
     } else if (control_code == KSU_KPM_UNLOAD) {
-        char kernel_name_buffer[256] = { 0 };
+        char kernel_name_buffer[KPM_PATH_LEN] = { 0 };
+        long n;
 
         if (arg1 == 0) {
             res = -EINVAL;
             goto exit;
         }
 
-        if (!ksu_access_ok(arg1, sizeof(kernel_name_buffer))) {
+        if (!ksu_access_ok((void __user *)(uintptr_t)arg1, 1))
             goto invalid_arg;
+
+        n = strncpy_from_user(kernel_name_buffer, (const char __user *)(uintptr_t)arg1, sizeof(kernel_name_buffer));
+        if (n < 0) {
+            res = (int)n;
+            goto exit;
+        }
+        if (n == 0 || n >= (long)sizeof(kernel_name_buffer)) {
+            res = -ENAMETOOLONG;
+            goto exit;
         }
 
-        strncpy_from_user((char *)&kernel_name_buffer, (const char *)arg1, sizeof(kernel_name_buffer));
-
-        sukisu_kpm_unload_module((const char *)&kernel_name_buffer, NULL, &res);
+        sukisu_kpm_unload_module(kernel_name_buffer, NULL, &res);
     } else if (control_code == KSU_KPM_NUM) {
         sukisu_kpm_num(&res);
     } else if (control_code == KSU_KPM_INFO) {
-        char kernel_name_buffer[256] = { 0 };
-        char buf[256] = { 0 };
-        int size;
+        char kernel_name_buffer[KPM_PATH_LEN] = { 0 };
+        char buf[KPM_INFO_BUF_LEN] = { 0 };
+        int size = 0;
+        long n;
 
         if (arg1 == 0 || arg2 == 0) {
             res = -EINVAL;
             goto exit;
         }
 
-        if (!ksu_access_ok(arg1, sizeof(kernel_name_buffer))) {
+        if (!ksu_access_ok((void __user *)(uintptr_t)arg1, 1))
             goto invalid_arg;
+
+        n = strncpy_from_user(kernel_name_buffer, (const char __user *)(uintptr_t)arg1, sizeof(kernel_name_buffer));
+        if (n < 0) {
+            res = (int)n;
+            goto exit;
+        }
+        if (n == 0 || n >= (long)sizeof(kernel_name_buffer)) {
+            res = -ENAMETOOLONG;
+            goto exit;
         }
 
-        strncpy_from_user((char *)&kernel_name_buffer, (const char __user *)arg1, sizeof(kernel_name_buffer));
+        sukisu_kpm_info(kernel_name_buffer, buf, sizeof(buf), &size);
 
-        sukisu_kpm_info((const char *)&kernel_name_buffer, (char *)&buf, sizeof(buf), &size);
-
-        if (!ksu_access_ok(arg2, size)) {
-            goto invalid_arg;
-        }
-
-        res = copy_to_user(arg2, &buf, size);
-
-    } else if (control_code == KSU_KPM_LIST) {
-        char buf[1024] = { 0 };
-        int len = (int)arg2;
-
-        if (len <= 0) {
+        if (size < 0 || size > (int)sizeof(buf)) {
             res = -EINVAL;
             goto exit;
         }
 
-        if (!ksu_access_ok(arg2, len)) {
-            goto invalid_arg;
+        if (size > 0) {
+            if (!ksu_access_ok((void __user *)(uintptr_t)arg2, size))
+                goto invalid_arg;
+
+            if (copy_to_user((void __user *)(uintptr_t)arg2, buf, size)) {
+                res = -EFAULT;
+                goto exit;
+            }
+        }
+        res = 0;
+    } else if (control_code == KSU_KPM_LIST) {
+        char buf[KPM_LIST_BUF_LEN] = { 0 };
+        int len = (int)arg2;
+        int copy_len;
+
+        if (arg1 == 0 || len <= 0) {
+            res = -EINVAL;
+            goto exit;
         }
 
-        sukisu_kpm_list((char *)&buf, sizeof(buf), &res);
+        /* arg1 = output buffer pointer, arg2 = buffer capacity */
+        if (!ksu_access_ok((void __user *)(uintptr_t)arg1, len))
+            goto invalid_arg;
+
+        sukisu_kpm_list(buf, sizeof(buf), &res);
+
+        if (res < 0)
+            goto exit;
+
+        if (res > (int)sizeof(buf)) {
+            res = -EOVERFLOW;
+            goto exit;
+        }
 
         if (res > len) {
             res = -ENOBUFS;
             goto exit;
         }
 
-        if (copy_to_user(arg1, &buf, len) != 0)
-            pr_info("kpm: Copy to user failed.");
-
+        copy_len = res;
+        if (copy_len > 0 && copy_to_user((void __user *)(uintptr_t)arg1, buf, copy_len)) {
+            res = -EFAULT;
+            goto exit;
+        }
     } else if (control_code == KSU_KPM_CONTROL) {
         char kpm_name[KPM_NAME_LEN] = { 0 };
         char kpm_args[KPM_ARGS_LEN] = { 0 };
+        long name_len;
+        long arg_len;
 
-        if (!ksu_access_ok(arg1, sizeof(kpm_name))) {
-            goto invalid_arg;
-        }
-
-        if (!ksu_access_ok(arg2, sizeof(kpm_args))) {
-            goto invalid_arg;
-        }
-
-        long name_len = strncpy_from_user((char *)&kpm_name, (const char __user *)arg1, sizeof(kpm_name));
-        if (name_len <= 0) {
+        if (arg1 == 0) {
             res = -EINVAL;
             goto exit;
         }
 
-        long arg_len = strncpy_from_user((char *)&kpm_args, (const char __user *)arg2, sizeof(kpm_args));
+        if (!ksu_access_ok((void __user *)(uintptr_t)arg1, 1))
+            goto invalid_arg;
 
-        sukisu_kpm_control((const char *)&kpm_name, (const char *)&kpm_args, arg_len, &res);
+        name_len = strncpy_from_user(kpm_name, (const char __user *)(uintptr_t)arg1, sizeof(kpm_name));
+        if (name_len <= 0) {
+            res = name_len < 0 ? (int)name_len : -EINVAL;
+            goto exit;
+        }
+        if (name_len >= (long)sizeof(kpm_name)) {
+            res = -ENAMETOOLONG;
+            goto exit;
+        }
 
+        if (arg2 != 0) {
+            if (!ksu_access_ok((void __user *)(uintptr_t)arg2, 1))
+                goto invalid_arg;
+
+            arg_len = strncpy_from_user(kpm_args, (const char __user *)(uintptr_t)arg2, sizeof(kpm_args));
+            if (arg_len < 0) {
+                res = (int)arg_len;
+                goto exit;
+            }
+            if (arg_len >= (long)sizeof(kpm_args)) {
+                res = -ENAMETOOLONG;
+                goto exit;
+            }
+        } else {
+            arg_len = 0;
+        }
+
+        sukisu_kpm_control(kpm_name, kpm_args, arg_len, &res);
     } else if (control_code == KSU_KPM_VERSION) {
-        char buffer[256] = { 0 };
-
-        sukisu_kpm_version((char *)&buffer, sizeof(buffer));
-
+        char buffer[KPM_VERSION_BUF_LEN] = { 0 };
         unsigned int outlen = (unsigned int)arg2;
-        int len = strlen(buffer);
-        if (len >= outlen)
-            len = outlen - 1;
+        int len;
 
-        res = copy_to_user(arg1, &buffer, len + 1);
+        if (arg1 == 0 || outlen == 0) {
+            res = -EINVAL;
+            goto exit;
+        }
+
+        if (!ksu_access_ok((void __user *)(uintptr_t)arg1, outlen))
+            goto invalid_arg;
+
+        sukisu_kpm_version(buffer, sizeof(buffer));
+
+        len = (int)strnlen(buffer, sizeof(buffer));
+        if (len >= (int)outlen)
+            len = (int)outlen - 1;
+
+        if (copy_to_user((void __user *)(uintptr_t)arg1, buffer, len + 1)) {
+            res = -EFAULT;
+            goto exit;
+        }
+        res = 0;
+    } else {
+        res = -EINVAL;
     }
 
 exit:
-    if (copy_to_user(result_code, &res, sizeof(res)) != 0)
-        pr_info("kpm: Copy to user failed.");
+    if (kpm_copy_result(result_code, res))
+        pr_info("kpm: Copy result to user failed.\n");
 
     return 0;
+
 invalid_arg:
-    pr_err("kpm: invalid pointer detected! arg1: %px arg2: %px\n", (void *)arg1, (void *)arg2);
+    pr_err("kpm: invalid pointer detected! arg1: %px arg2: %px\n", (void *)(uintptr_t)arg1,
+           (void *)(uintptr_t)arg2);
     res = -EFAULT;
     goto exit;
 }
@@ -270,13 +401,14 @@ int do_kpm(void __user *arg)
         return -EFAULT;
     }
 
-    if (!ksu_access_ok(cmd.control_code, sizeof(int))) {
-        pr_err("kpm: invalid control_code pointer %px\n", (void *)cmd.control_code);
-        return -EFAULT;
+    /* control_code is a command value (KSU_KPM_*), not a user pointer. */
+    if (cmd.control_code < CMD_KPM_CONTROL || cmd.control_code > CMD_KPM_CONTROL_MAX) {
+        pr_err("kpm: invalid control_code %llu\n", (unsigned long long)cmd.control_code);
+        return -EINVAL;
     }
 
-    if (!ksu_access_ok(cmd.result_code, sizeof(int))) {
-        pr_err("kpm: invalid result_code pointer %px\n", (void *)cmd.result_code);
+    if (!cmd.result_code || !ksu_access_ok((void __user *)(uintptr_t)cmd.result_code, sizeof(int))) {
+        pr_err("kpm: invalid result_code pointer %px\n", (void *)(uintptr_t)cmd.result_code);
         return -EFAULT;
     }
 

--- a/kernel/kpm/kpm.c
+++ b/kernel/kpm/kpm.c
@@ -190,8 +190,8 @@ noinline int sukisu_handle_kpm(unsigned long control_code, unsigned long arg1, u
             if (!ksu_access_ok((void __user *)(uintptr_t)arg2, 1))
                 goto invalid_arg;
 
-            n = strncpy_from_user(kernel_args_buffer, (const char __user *)(uintptr_t)arg2,
-                                  sizeof(kernel_args_buffer));
+            n = strncpy_from_user(kernel_args_buffer,
+                                  (const char __user *)(uintptr_t)arg2, sizeof(kernel_args_buffer));
             if (n < 0) {
                 res = (int)n;
                 goto exit;
@@ -380,8 +380,8 @@ exit:
     return 0;
 
 invalid_arg:
-    pr_err("kpm: invalid pointer detected! arg1: %px arg2: %px\n", (void *)(uintptr_t)arg1,
-           (void *)(uintptr_t)arg2);
+    pr_err("kpm: invalid pointer detected! arg1: %px arg2: %px\n",
+           (void *)(uintptr_t)arg1, (void *)(uintptr_t)arg2);
     res = -EFAULT;
     goto exit;
 }

--- a/kernel/kpm/kpm.c
+++ b/kernel/kpm/kpm.c
@@ -187,11 +187,12 @@ noinline int sukisu_handle_kpm(unsigned long control_code, unsigned long arg1, u
         }
 
         if (arg2 != 0) {
-            if (!ksu_access_ok((void __user *)(uintptr_t)arg2, 1))
+            const char __user *args_user = (const char __user *)(uintptr_t)arg2;
+
+            if (!ksu_access_ok(args_user, 1))
                 goto invalid_arg;
 
-            n = strncpy_from_user(kernel_args_buffer,
-                                  (const char __user *)(uintptr_t)arg2, sizeof(kernel_args_buffer));
+            n = strncpy_from_user(kernel_args_buffer, args_user, sizeof(kernel_args_buffer));
             if (n < 0) {
                 res = (int)n;
                 goto exit;
@@ -380,8 +381,7 @@ exit:
     return 0;
 
 invalid_arg:
-    pr_err("kpm: invalid pointer detected! arg1: %px arg2: %px\n",
-           (void *)(uintptr_t)arg1, (void *)(uintptr_t)arg2);
+    pr_err("kpm: invalid user pointer arg1=%px arg2=%px\n", (void *)(uintptr_t)arg1, (void *)(uintptr_t)arg2);
     res = -EFAULT;
     goto exit;
 }

--- a/kernel/kpm/kpm.h
+++ b/kernel/kpm/kpm.h
@@ -3,13 +3,14 @@
 
 #include <linux/types.h>
 #include <linux/ioctl.h>
+#include "uapi/supercall.h"
 
 int sukisu_handle_kpm(unsigned long control_code, unsigned long arg1, unsigned long arg2, unsigned long result_code);
 int sukisu_is_kpm_control_code(unsigned long control_code);
 int do_kpm(void __user *arg);
 
-/* KPM Control Code */
-#define CMD_KPM_CONTROL 1
+/* KPM Control Code range (matches KSU_KPM_* in uapi/supercall.h) */
+#define CMD_KPM_CONTROL KSU_KPM_LOAD
 #define CMD_KPM_CONTROL_MAX 10
 
 #endif

--- a/uapi/supercall.h
+++ b/uapi/supercall.h
@@ -187,20 +187,21 @@ struct ksu_get_managers_cmd {
     struct ksu_manager_entry managers[]; // Output: Array of active manager
 } __attribute__((packed));
 
-DEFINE_KSU_UAPI_CONST(__u8, KSU_KPM_LOAD, 1)
-DEFINE_KSU_UAPI_CONST(__u8, KSU_KPM_UNLOAD, 2)
-DEFINE_KSU_UAPI_CONST(__u8, KSU_KPM_NUM, 3)
-DEFINE_KSU_UAPI_CONST(__u8, KSU_KPM_LIST, 4)
-DEFINE_KSU_UAPI_CONST(__u8, KSU_KPM_INFO, 5)
-DEFINE_KSU_UAPI_CONST(__u8, KSU_KPM_CONTROL, 6)
-DEFINE_KSU_UAPI_CONST(__u8, KSU_KPM_VERSION, 7)
+/* Match SukiSU-Ultra ABI: control_code is a u64 command *value*, not a pointer. */
+DEFINE_KSU_UAPI_CONST(__u32, KSU_KPM_LOAD, 1)
+DEFINE_KSU_UAPI_CONST(__u32, KSU_KPM_UNLOAD, 2)
+DEFINE_KSU_UAPI_CONST(__u32, KSU_KPM_NUM, 3)
+DEFINE_KSU_UAPI_CONST(__u32, KSU_KPM_LIST, 4)
+DEFINE_KSU_UAPI_CONST(__u32, KSU_KPM_INFO, 5)
+DEFINE_KSU_UAPI_CONST(__u32, KSU_KPM_CONTROL, 6)
+DEFINE_KSU_UAPI_CONST(__u32, KSU_KPM_VERSION, 7)
 
 struct ksu_kpm_cmd {
-    __u8 __user control_code;
-    __aligned_u64 __user arg1;
-    __aligned_u64 __user arg2;
-    __aligned_u64 __user result_code;
-} __attribute__((packed));
+    __aligned_u64 control_code; /* Input: KSU_KPM_* command value */
+    __aligned_u64 __user arg1; /* Input: path/name/buffer pointer (per cmd) */
+    __aligned_u64 __user arg2; /* Input: args pointer or buffer size (per cmd) */
+    __aligned_u64 __user result_code; /* Input: pointer to int for result */
+};
 
 DEFINE_KSU_UAPI_CONST(__u8, KERNEL_PATCH_NOT_FOUND, 0)
 DEFINE_KSU_UAPI_CONST(__u8, KERNEL_PATCH_ORIGINAL, 1)

--- a/userspace/ksud/src/android/kpm.rs
+++ b/userspace/ksud/src/android/kpm.rs
@@ -20,7 +20,7 @@ where
 
     let mut ret = -1;
     let mut cmd = uapi::ksu_kpm_cmd {
-        control_code: uapi::KSU_KPM_LOAD_RUST,
+        control_code: u64::from(uapi::KSU_KPM_LOAD_RUST),
         arg1: path.as_ptr() as u64,
         arg2: args.as_ptr() as u64,
         result_code: &raw mut ret as u64,
@@ -39,7 +39,7 @@ pub fn list() -> Result<()> {
 
     let mut ret = -1;
     let mut cmd = uapi::ksu_kpm_cmd {
-        control_code: uapi::KSU_KPM_LIST_RUST,
+        control_code: u64::from(uapi::KSU_KPM_LIST_RUST),
         arg1: buf.as_mut_ptr() as u64,
         arg2: buf.len() as u64,
         result_code: &raw mut ret as u64,
@@ -65,7 +65,7 @@ pub fn unload_module(name: String) -> Result<()> {
 
     let mut ret = -1;
     let mut cmd = uapi::ksu_kpm_cmd {
-        control_code: uapi::KSU_KPM_UNLOAD_RUST,
+        control_code: u64::from(uapi::KSU_KPM_UNLOAD_RUST),
         arg1: name.as_ptr() as u64,
         arg2: 0,
         result_code: &raw mut ret as u64,
@@ -88,7 +88,7 @@ pub fn info(name: String) -> Result<()> {
 
     let mut ret = -1;
     let mut cmd = uapi::ksu_kpm_cmd {
-        control_code: uapi::KSU_KPM_INFO_RUST,
+        control_code: u64::from(uapi::KSU_KPM_INFO_RUST),
         arg1: name.as_ptr() as u64,
         arg2: buf.as_mut_ptr() as u64,
         result_code: &raw mut ret as u64,
@@ -113,7 +113,7 @@ pub fn control(name: String, args: String) -> Result<i32> {
 
     let mut ret = -1;
     let mut cmd = uapi::ksu_kpm_cmd {
-        control_code: uapi::KSU_KPM_CONTROL_RUST,
+        control_code: u64::from(uapi::KSU_KPM_CONTROL_RUST),
         arg1: name.as_ptr() as u64,
         arg2: args.as_ptr() as u64,
         result_code: &raw mut ret as u64,
@@ -134,7 +134,7 @@ pub fn control(name: String, args: String) -> Result<i32> {
 pub fn num() -> Result<i32> {
     let mut ret = -1;
     let mut cmd = uapi::ksu_kpm_cmd {
-        control_code: uapi::KSU_KPM_NUM_RUST,
+        control_code: u64::from(uapi::KSU_KPM_NUM_RUST),
         arg1: 0,
         arg2: 0,
         result_code: &raw mut ret as u64,
@@ -158,7 +158,7 @@ pub fn version() -> Result<()> {
 
     let mut ret = -1;
     let mut cmd = uapi::ksu_kpm_cmd {
-        control_code: uapi::KSU_KPM_VERSION_RUST,
+        control_code: u64::from(uapi::KSU_KPM_VERSION_RUST),
         arg1: buf.as_mut_ptr() as u64,
         arg2: buf.len() as u64,
         result_code: &raw mut ret as u64,
@@ -186,7 +186,7 @@ pub fn check_version() -> Result<String> {
 
     let mut ret = -1;
     let mut cmd = uapi::ksu_kpm_cmd {
-        control_code: uapi::KSU_KPM_VERSION_RUST,
+        control_code: u64::from(uapi::KSU_KPM_VERSION_RUST),
         arg1: buf.as_mut_ptr() as u64,
         arg2: buf.len() as u64,
         result_code: &raw mut ret as u64,
@@ -219,8 +219,10 @@ fn ensure_dir() -> Result<()> {
         let _ = fs::create_dir_all(KPM_DIR);
     }
 
-    if dir.metadata()?.permissions().mode() != 0o777 {
-        fs::set_permissions(KPM_DIR, fs::Permissions::from_mode(0o777))?;
+    // Root-only: world-writable kpm dir would let any app drop modules for boot load.
+    let mode = dir.metadata()?.permissions().mode() & 0o777;
+    if mode != 0o700 {
+        fs::set_permissions(KPM_DIR, fs::Permissions::from_mode(0o700))?;
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Align `ksu_kpm_cmd` with SukiSU-Ultra ABI (`control_code` as `u64` command value)
- Harden KPM ioctl handlers (LIST/INFO/VERSION bounds, correct `access_ok` targets)
- Restore compact ABI helpers for manager uid + exact symbol resolve
- Lock down `/data/adb/kpm` directory permissions to `0700`

## Test plan
- [ ] CI: ClangFormat, Clippy, Rustfmt, Build Manager (PR checks)
- [ ] With `CONFIG_KPM=y`, confirm KPM ioctl no longer fails on control_code layout
- [ ] ksud kpm list/version/num against stub returns clean errors (ENOSYS / empty)